### PR TITLE
zsh: remove deprecated keys, add new key

### DIFF
--- a/queries/nix/injections.scm
+++ b/queries/nix/injections.scm
@@ -75,7 +75,7 @@
 ; Zsh
 (binding
   attrpath: (_) @_path
-  (#hmts-path? @_path "programs" "zsh" "(completionInit|envExtra|initExtra|initExtraBeforeCompInit|initExtraFirst|loginExtra|logoutExtra|profileExtra)$")
+  (#hmts-path? @_path "programs" "zsh" "(completionInit|envExtra|initContent|loginExtra|logoutExtra|profileExtra)$")
   expression: (_ (string_fragment) @injection.content)
   (#set! injection.language "bash")
   (#set! injection.combined)


### PR DESCRIPTION
- [deprecated key]
  - [use this instead]
 
-----

- `initExtra`
  - `initContent`
- `initExtraFirst`
  - `initContent` with `lib.mkBefore`
- `initExtraBeforeCompInit`
  - `initContent` with `lib.mkOrder 550`
